### PR TITLE
Allow lambda to query clean.pageviews

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -74,6 +74,7 @@ Resources:
               Effect: Allow
               Action:
                 - glue:GetDatabase
+                - glue:GetTable
                 - glue:CreateDatabase
               Resource:
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -79,6 +79,7 @@ Resources:
               Resource:
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/default
+                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/clean
         - PolicyName: s3CleanPageViewsAccess
           PolicyDocument:
             Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -59,6 +59,36 @@ Resources:
               Action:
                 - SNS:Publish
               Resource: !Ref SnsTopicForAlerts
+        - PolicyName: athenaReadAccess
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - athena:StartQueryExecution
+                - athena:GetQueryExecution
+                - athena:GetQueryResults
+              Resource: "*"
+        - PolicyName: s3CleanPageViewsAccess
+            PolicyDocument:
+              Statement:
+                Effect: Allow
+                Action:
+                  - s3:Get*
+                  - s3:List*
+                Resource: arn:aws:s3:::ophan-clean-pageview/*
+        - PolicyName: s3QueryResultsAccess
+            PolicyDocument:
+              Statement:
+                Effect: Allow
+                  Action:
+                    - s3:GetObject
+                    - s3:ListBucketMultipartUploads
+                    - s3:ListMultipartUploadParts
+                    - s3:AbortMultipartUpload
+                    - s3:PutObject
+                  Resource:
+                    - arn:aws:s3:::aws-athena-query-results-*/*'
+
   Lambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -87,7 +87,7 @@ Resources:
                     - s3:AbortMultipartUpload
                     - s3:PutObject
                   Resource:
-                    - arn:aws:s3:::aws-athena-query-results-*/*'
+                    - arn:aws:s3:::aws-athena-query-results-*/data-lake-alerts/*'
 
   Lambda:
     Type: AWS::Lambda::Function

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -75,11 +75,21 @@ Resources:
               Action:
                 - glue:GetDatabase
                 - glue:GetTable
+                - glue:GetPartitions
                 - glue:CreateDatabase
               Resource:
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/default
+        - PolicyName: cleanGlueAccess
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - glue:GetTable
+                - glue:GetPartitions
+              Resource:
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/clean
+                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/clean/pageview
         - PolicyName: s3CleanPageViewsAccess
           PolicyDocument:
             Statement:
@@ -87,7 +97,9 @@ Resources:
               Action:
                 - s3:Get*
                 - s3:List*
-              Resource: arn:aws:s3:::ophan-clean-pageview/*
+              Resource:
+              - arn:aws:s3:::ophan-clean-pageview
+              - arn:aws:s3:::ophan-clean-pageview/*
         - PolicyName: s3QueryResultsAccess
           PolicyDocument:
             Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -69,25 +69,25 @@ Resources:
                 - athena:GetQueryResults
               Resource: "*"
         - PolicyName: s3CleanPageViewsAccess
-            PolicyDocument:
-              Statement:
-                Effect: Allow
-                Action:
-                  - s3:Get*
-                  - s3:List*
-                Resource: arn:aws:s3:::ophan-clean-pageview/*
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - s3:Get*
+                - s3:List*
+              Resource: arn:aws:s3:::ophan-clean-pageview/*
         - PolicyName: s3QueryResultsAccess
-            PolicyDocument:
-              Statement:
-                Effect: Allow
-                  Action:
-                    - s3:GetObject
-                    - s3:ListBucketMultipartUploads
-                    - s3:ListMultipartUploadParts
-                    - s3:AbortMultipartUpload
-                    - s3:PutObject
-                  Resource:
-                    - arn:aws:s3:::aws-athena-query-results-*/data-lake-alerts/*'
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:ListBucketMultipartUploads
+                - s3:ListMultipartUploadParts
+                - s3:AbortMultipartUpload
+                - s3:PutObject
+              Resource:
+                - arn:aws:s3:::aws-athena-query-results-*/data-lake-alerts/*
 
   Lambda:
     Type: AWS::Lambda::Function

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -76,7 +76,6 @@ Resources:
                 - glue:GetDatabase
                 - glue:GetTable
                 - glue:GetPartitions
-                - glue:CreateDatabase
               Resource:
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
                 - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/default

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -68,6 +68,16 @@ Resources:
                 - athena:GetQueryExecution
                 - athena:GetQueryResults
               Resource: "*"
+        - PolicyName: mandatoryGlueAccess
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - glue:GetDatabase
+                - glue:CreateDatabase
+              Resource:
+                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/default
         - PolicyName: s3CleanPageViewsAccess
           PolicyDocument:
             Statement:

--- a/src/main/scala/com/gu/datalakealerts/Athena.scala
+++ b/src/main/scala/com/gu/datalakealerts/Athena.scala
@@ -19,7 +19,7 @@ object Athena {
   def startQuery(monitoringQuery: MonitoringQuery): StartQueryExecutionResult = {
     val startQueryRequest: StartQueryExecutionRequest = new StartQueryExecutionRequest()
       .withQueryString(monitoringQuery.query)
-      .withResultConfiguration(new ResultConfiguration().withOutputLocation("s3://aws-athena-query-results-021353022223-eu-west-1")) // Ophan temp bucket
+      .withResultConfiguration(new ResultConfiguration().withOutputLocation("s3://aws-athena-query-results-021353022223-eu-west-1/data-lake-alerts")) // Ophan temp bucket
     client.startQueryExecution(startQueryRequest)
   }
 


### PR DESCRIPTION
This PR adds the correct IAM permissions for the lambda (at the moment it just needs to be able to query clean.pageviews).