### PR TITLE
Add schedule for daily monitoring

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -132,3 +132,28 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60
+
+  MonitoringSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt Lambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt MonitoringSchedule.Arn
+
+  MonitoringSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub data-lake-alerts-monitoring-schedule-${Stage}
+      ScheduleExpression: cron(0 6 ? * MON-FRI *)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt Lambda.Arn
+          Id: ios-friction-screen-scheduler
+          Input: |
+            {
+              "featureId": "friction_screen",
+              "platformId": "ios"
+            }
+    DependsOn:
+      - Lambda

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -155,5 +155,3 @@ Resources:
               "featureId": "friction_screen",
               "platformId": "ios"
             }
-    DependsOn:
-      - Lambda


### PR DESCRIPTION
Allows us to schedule a monitoring/alerting task on weekdays at 6am.

Currently this will monitor friction_screen impressions on iOS (as a first example).