### PR TITLE
Add some documentation to help teams add their own monitoring tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The simplest option is to run the monitoring task on a daily basis, using a Sche
     
     ```
     {
-        platform: "android"
-        feature: "my_feature_id"    
+      "featureId": "friction_screen",
+      "platformId": "ios"
     }
     ```
 However, as this monitoring task runs as a lambda function, it's possible to use a different trigger

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # data-lake-alerts
 
-Query the data lake and alert if thresholds are breached
+Allows developers to detect production issues, by automating the process of querying the Data Lake 
+and alerting on undesirable results.
+
+## Adding a new alert
+
+###Before you start:
+
+You will need to be able to run queries against the Data Lake using `AWS Athena`, 
+so you'll need to request `dataLakeQuerying` permissions via Janus if you do not already have access.
+
+Currently this service has read-only access to the `clean.pageviews` table only. If you need to run queries against 
+a different table, you'll need to add further permissions to the Cloudformation template in this repository.
+
+###Adding the alert:
+
+1. Write your query and test it using Athena. 
+    1. The Athena pricing model is based on data scanned, so try not to scan more data than necessary.
+1. Add `MyFeature extends Feature { ??? }` to the `Features` object. You will need to provide:
+    1. A feature id (used when triggering the lambda)
+    1. A function which returns your query (to be run by Athena).
+    1. A function which performs a check on the query's results and (optionally) 
+    additional debug information which will be included in the alert in the event of a failure.
+1. Add your feature to `allFeaturesWithMonitoring` (also in the `Features` object).
+
+###Testing your changes
+
+1. Obtain `developerPlayground` and `ophan` Janus credentials.
+1. Edit the `TestIt` object, passing in your `Platform` and `Feature`.
+1. Run `sbt run`.
+
+###Triggering the monitoring task regularly
+
+1. Add a CloudWatch rule to the repo's CloudFormation template.
+    1. The input event should look something like this:
+    
+    ```
+    {
+        platform: "android"
+        feature: "my_feature_id"    
+    }
+    ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ a different table, you'll need to add further permissions to the Cloudformation 
 1. Edit the `TestIt` object, passing in your `Platform` and `Feature`.
 1. Run `sbt run`.
 
-###Triggering the monitoring task regularly
+###Triggering the monitoring task
+
+The simplest option is to run the monitoring task on a daily basis, using a Scheduled Event.
 
 1. Add a CloudWatch rule to the repo's CloudFormation template.
     1. The input event should look something like this:
@@ -41,3 +43,5 @@ a different table, you'll need to add further permissions to the Cloudformation 
         feature: "my_feature_id"    
     }
     ```
+However, as this monitoring task runs as a lambda function, it's possible to use a different trigger
+event (e.g. another lambda) to invoke the function with the relevant input event.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Allows developers to detect production issues, by automating the process of querying the Data Lake 
 and alerting on undesirable results.
 
-## Adding a new alert
+Adding a new alert
+------------------
 
-###Before you start:
+### Before you start:
 
 You will need to be able to run queries against the Data Lake using `AWS Athena`, 
 so you'll need to request `dataLakeQuerying` permissions via Janus if you do not already have access.
@@ -13,7 +14,7 @@ so you'll need to request `dataLakeQuerying` permissions via Janus if you do not
 Currently this service has read-only access to the `clean.pageviews` table only. If you need to run queries against 
 a different table, you'll need to add further permissions to the Cloudformation template in this repository.
 
-###Adding the alert:
+### Adding the alert:
 
 1. Write your query and test it using Athena. 
     1. The Athena pricing model is based on data scanned, so try not to scan more data than necessary.
@@ -24,13 +25,13 @@ a different table, you'll need to add further permissions to the Cloudformation 
     additional debug information which will be included in the alert in the event of a failure.
 1. Add your feature to `allFeaturesWithMonitoring` (also in the `Features` object).
 
-###Testing your changes
+### Testing your changes
 
 1. Obtain `developerPlayground` and `ophan` Janus credentials.
 1. Edit the `TestIt` object, passing in your `Platform` and `Feature`.
 1. Run `sbt run`.
 
-###Triggering the monitoring task
+### Triggering the monitoring task
 
 The simplest option is to run the monitoring task on a daily basis, using a Scheduled Event.
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,17 @@ a different table, you'll need to add further permissions to the Cloudformation 
 
 The simplest option is to run the monitoring task on a daily basis, using a Scheduled Event.
 
-1. Add a CloudWatch rule to the repo's CloudFormation template.
-    1. The input event should look something like this:
+1. Add a new Target to the `MonitoringSchedule` (in cfn.yaml). It should look something like this:
     
     ```
-    {
-      "featureId": "friction_screen",
-      "platformId": "ios"
-    }
+    - Arn: !GetAtt Lambda.Arn
+      Id: ios-friction-screen-scheduler
+      Input: |
+        {
+          "featureId": "friction_screen",
+          "platformId": "ios"
+        }
     ```
+    
 However, as this monitoring task runs as a lambda function, it's possible to use a different trigger
 event (e.g. another lambda) to invoke the function with the relevant input event.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and alerting on undesirable results.
 Adding a new alert
 ------------------
 
-### Before you start:
+### Before you start
 
 You will need to be able to run queries against the Data Lake using `AWS Athena`, 
 so you'll need to request `dataLakeQuerying` permissions via Janus if you do not already have access.
@@ -14,7 +14,7 @@ so you'll need to request `dataLakeQuerying` permissions via Janus if you do not
 Currently this service has read-only access to the `clean.pageviews` table only. If you need to run queries against 
 a different table, you'll need to add further permissions to the Cloudformation template in this repository.
 
-### Adding the alert:
+### Adding the alert
 
 1. Write your query and test it using Athena. 
     1. The Athena pricing model is based on data scanned, so try not to scan more data than necessary.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ The simplest option is to run the monitoring task on a daily basis, using a Sche
     
 However, as this monitoring task runs as a lambda function, it's possible to use a different trigger
 event (e.g. another lambda) to invoke the function with the relevant input event.
+
+You should deploy this change to `CODE` to ensure that your Cloudformation changes are valid.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ a different table, you'll need to add further permissions to the Cloudformation 
 1. Obtain `developerPlayground` and `ophan` Janus credentials.
 1. Run `sbt "run my_platform my_feature"` (passing in the relevant `Platform` and `Feature` ids).
 
+Note that (by default) an alert will *not* be sent when running locally (although there will be logging which indicates that an alert _would_ have been sent). This is to prevent people from unintentionally spamming their teams when testing changes. If you really want to send an alert, you can do so by setting [Anghammarad](https://github.com/guardian/anghammarad)'s SNS topic [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) as an environment variable called `SnsTopicForAlerts`.
+
 ### Triggering the monitoring task
 
 The simplest option is to run the monitoring task on a daily basis, using a Scheduled Event.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ a different table, you'll need to add further permissions to the Cloudformation 
 ### Testing your changes
 
 1. Obtain `developerPlayground` and `ophan` Janus credentials.
-1. Edit the `TestIt` object, passing in your `Platform` and `Feature`.
-1. Run `sbt run`.
+1. Run `sbt "run my_platform my_feature"` (passing in the relevant `Platform` and `Feature` ids).
 
 ### Triggering the monitoring task
 


### PR DESCRIPTION
Basic documentation to help developers add their own alerts.

Unfortunately this shows that there is still plenty of work required to make it easier to add monitoring for new features!