### PR TITLE
Add debug statement and increase timeout

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -131,7 +131,7 @@ Resources:
       MemorySize: 1536
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 60
+      Timeout: 180
 
   MonitoringSchedulePermission:
     Type: AWS::Lambda::Permission

--- a/src/main/scala/com/gu/datalakealerts/Athena.scala
+++ b/src/main/scala/com/gu/datalakealerts/Athena.scala
@@ -33,6 +33,7 @@ object Athena {
       Thread.sleep(1000)
       val shouldStopPolling = {
         val status = client.getQueryExecution(getQueryExecutionRequest).getQueryExecution.getStatus.getState
+        logger.info(s"Query $queryExecutionId status is: $status")
         status == "SUCCEEDED" || status == "FAILED" || status == "CANCELLED"
       }
       waitForQueryToComplete(queryExecutionId, shouldStopPolling)


### PR DESCRIPTION
The lambda has timed out a few times whilst waiting for the Athena query to complete.

This is quite odd because according to Athena's History tab, the queries always appear to complete successfully in ~15 seconds.

![image](https://user-images.githubusercontent.com/19384074/61616702-15429100-ac61-11e9-8c6a-c026b487aad1.png)

I don't really understand this problem yet - I've never seen it when testing but it seems to happen quite consistently when this lambda is run on the early morning schedule. This PR extends the timeout and adds a new log line to try and help me to understand what's going wrong...