### PR TITLE
Fix permissions after workgroup changes

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -110,7 +110,7 @@ Resources:
                 - s3:AbortMultipartUpload
                 - s3:PutObject
               Resource:
-                - arn:aws:s3:::aws-athena-query-results-*/data-lake-alerts/*
+                - arn:aws:s3:::aws-athena-query-results-*/primary/*
 
   Lambda:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/datalakealerts/Athena.scala
+++ b/src/main/scala/com/gu/datalakealerts/Athena.scala
@@ -19,7 +19,7 @@ object Athena {
   def startQuery(monitoringQuery: MonitoringQuery): StartQueryExecutionResult = {
     val startQueryRequest: StartQueryExecutionRequest = new StartQueryExecutionRequest()
       .withQueryString(monitoringQuery.query)
-      .withResultConfiguration(new ResultConfiguration().withOutputLocation("s3://aws-athena-query-results-021353022223-eu-west-1/data-lake-alerts")) // Ophan temp bucket
+      .withWorkGroup("primary") //TODO: consider using a dedicated workgroup
     client.startQueryExecution(startQueryRequest)
   }
 


### PR DESCRIPTION
This was broken due to some changes to the workgroups in the Ophan account.

[Override client-side settings ](https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html)has been enabled, which means that query results will now always be written to `/primary` instead of `/data-lake-alerts`.

I think there would be some advantages to using a dedicated workgroup for this lambda (and perhaps other 'machine users'), so have added a note to remind myself to consider this for another PR.

