### PR TITLE
Allow developers to send alerts locally without spamming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ a different table, you'll need to add further permissions to the Cloudformation 
 1. Obtain `developerPlayground` and `ophan` Janus credentials.
 1. Run `sbt "run my_platform my_feature"` (passing in the relevant `Platform` and `Feature` ids).
 
-Note that (by default) an alert will *not* be sent when running locally (although there will be logging which indicates that an alert _would_ have been sent). This is to prevent people from unintentionally spamming their teams when testing changes. If you really want to send an alert, you can do so by setting [Anghammarad](https://github.com/guardian/anghammarad)'s SNS topic [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) as an environment variable called `SnsTopicForAlerts`.
+Note that when running locally or in the `CODE` environment all alerts will be sent to the `anghammarad.test.alerts` Google Group 
+(instead of the team who maintains the specified production stack).
+
+This allows you to send test alerts in these environments without spamming your team.
 
 ### Triggering the monitoring task
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.604",
   "com.gu" %% "anghammarad-client" % "1.0.4",
   "org.slf4j" % "slf4j-api" % "1.7.26",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",

--- a/src/main/scala/com/gu/datalakealerts/Lambda.scala
+++ b/src/main/scala/com/gu/datalakealerts/Lambda.scala
@@ -1,6 +1,8 @@
 package com.gu.datalakealerts
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest
 import com.gu.anghammarad.{ AWS, Anghammarad }
 import com.gu.anghammarad.models._
 import com.gu.datalakealerts.Features.Feature
@@ -30,38 +32,53 @@ case class Env(app: String, stack: String, stage: String, snsTopicForAlerts: Str
 }
 
 object Env {
+
+  // Only used when running locally
+  lazy val ssmClient = AWSSimpleSystemsManagementClientBuilder
+    .standard()
+    .withCredentials(AwsCredentials.notificationCredentials)
+    .build()
+
+  // Only used when running locally
+  lazy val snsTopicFromParameterStore = {
+    logger.info("Reading Anghammarad SNS topic from Parameter Store...")
+    ssmClient.getParameter(
+      new GetParameterRequest().withName("/DEV/data-lake-alerts/anghammarad-sns-topic")).getParameter.getValue
+  }
+
   def apply(): Env = Env(
     Option(System.getenv("App")).getOrElse("DEV"),
     Option(System.getenv("Stack")).getOrElse("DEV"),
     Option(System.getenv("Stage")).getOrElse("DEV"),
-    Option(System.getenv("SnsTopicForAlerts")).getOrElse("DEV"))
+    Option(System.getenv("SnsTopicForAlerts")).getOrElse(snsTopicFromParameterStore))
 }
 
 object Notifications {
 
   val env = Env()
 
-  def alert(featureId: String, executionId: String, message: Option[String], stack: Stack) = {
+  def alert(featureId: String, executionId: String, message: Option[String], stackForProductionAlerts: Stack) = {
 
-    if (env.snsTopicForAlerts == "DEV") {
-      logger.info(s"Alert function called when running locally: an alert will NOT actually be sent unless SnsTopicForAlerts env variable is provided (to avoid spamming your team)")
-    } else {
-      val notificationAttempt = Anghammarad.notify(
-        subject = s"Data Lake Monitoring | Check Failed for ${featureId}",
-        message = message.getOrElse(s"Check failed when monitoring ${featureId}"),
-        sourceSystem = "Data Lake Alerts",
-        channel = Email,
-        target = List(stack),
-        actions = List(Action(
-          cta = "View Query Results [Requires Ophan AWS Console Access]",
-          url = s"https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#query/history/${executionId}")),
-        topicArn = env.snsTopicForAlerts,
-        client = AWS.snsClient(AwsCredentials.notificationCredentials))
+    val stack = env.stage match {
+      case "PROD" => stackForProductionAlerts
+      case _ => Stack("testing-alerts") // Alerts sent in DEV and CODE will go to the 'anghammarad.test.alerts' Google Group (to avoid spam)
+    }
 
-      Try(Await.result(notificationAttempt, 10.seconds)) match {
-        case Success(_) => logger.info("Sent notification via Anghammarad")
-        case Failure(ex) => logger.error(s"Failed to send notification due to $ex")
-      }
+    val notificationAttempt = Anghammarad.notify(
+      subject = s"Data Lake Monitoring | Check Failed for ${featureId}",
+      message = message.getOrElse(s"Check failed when monitoring ${featureId}"),
+      sourceSystem = "Data Lake Alerts",
+      channel = Email,
+      target = List(stack),
+      actions = List(Action(
+        cta = "View Query Results [Requires Ophan AWS Console Access]",
+        url = s"https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#query/history/${executionId}")),
+      topicArn = env.snsTopicForAlerts,
+      client = AWS.snsClient(AwsCredentials.notificationCredentials))
+
+    Try(Await.result(notificationAttempt, 10.seconds)) match {
+      case Success(_) => logger.info("Sent notification via Anghammarad")
+      case Failure(ex) => logger.error(s"Failed to send notification due to $ex")
     }
 
   }
@@ -86,7 +103,12 @@ object Lambda {
     Athena.waitForQueryToComplete(queryExecutionId)
     val monitoringResult = feature.monitoringQueryResult(Athena.retrieveResult(queryExecutionId), monitoringQuery.minimumImpressionsThreshold)
     if (!monitoringResult.resultIsAcceptable) {
-      Notifications.alert(feature.id, queryExecutionId, monitoringResult.additionalDebugInformation, Stack(platform.id))
+      Notifications.alert(
+        featureId = feature.id,
+        executionId = queryExecutionId,
+        monitoringResult.additionalDebugInformation,
+        stackForProductionAlerts = Stack(platform.id) //This stack will be overridden in other environments (to avoid spam)
+      )
     } else {
       logger.info(s"Monitoring ran successfully for ${feature.id}. No problems were detected.")
     }


### PR DESCRIPTION
This PR makes it easier to test alerts when running locally.

Previously developers would have to obtain the Anghammarad SNS topic, set an environment variable and then send an email to their whole team in order to test an alert. This is obviously undesirable for a number of reasons!

Now we read the SNS topic from AWS Parameter store when running locally (which means less effort/frustration for developers who want to send a test alert). We also override the stack which is passed to Anghammarad in DEV/CODE, so that test alerts are sent to a dedicated Google Group (which means there is less spam for teams).

All of the Parameter Store values are initialised lazily. These `lazy val`s should never be accessed when running inside a lambda, so this should only affect local development.
