### PR TITLE
Add query for iOS epic

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -169,3 +169,10 @@ Resources:
               "featureId": "epic",
               "platformId": "android"
             }
+        - Arn: !GetAtt Lambda.Arn
+          Id: ios-epic-scheduler
+          Input: |
+            {
+              "featureId": "epic",
+              "platformId": "ios"
+            }

--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -8,7 +8,7 @@ import com.gu.datalakealerts.Platforms.{ Android, iOS, Platform }
 object Features {
 
   val yesterday: LocalDate = LocalDate.now().minusDays(1)
-  val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, EpicAndroidFeature)
+  val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, Epic)
 
   def featureToMonitor(featureId: String): Feature = {
     allFeaturesWithMonitoring
@@ -71,7 +71,7 @@ object Features {
 
   }
 
-  case object EpicAndroidFeature extends Feature {
+  case object Epic extends Feature {
     override val id = "epic"
 
     override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {

--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -3,7 +3,7 @@ package com.gu.datalakealerts
 import java.time.LocalDate
 
 import com.amazonaws.services.athena.model.ResultSet
-import com.gu.datalakealerts.Platforms.{ Android, Platform }
+import com.gu.datalakealerts.Platforms.{ Android, iOS, Platform }
 
 object Features {
 
@@ -106,7 +106,18 @@ object Features {
             |and ab.completed = True
             |group by 1
           """.stripMargin, 285000)
-        case _ => throw new RuntimeException("Only Android platform is supported.")
+        case iOS => 
+          MonitoringQuery(s"""
+            |select browser_version, count (distinct page_view_id) as epic_impressions
+            |from clean.pageview
+            |cross join unnest (ab_tests) x (ab)
+            |where received_date = date '$yesterday'
+            |and path not like '%.mp3%'
+            |and device_type like '%IOS%'
+            |and ab.name like '%epic%'
+            |and ab.completed = False
+            |group by 1
+          """.stripMargin, 617315)
       }
     }
   }


### PR DESCRIPTION
I've also renamed the feature `Epic` from `EpicAndroidFeature` since it handles both platforms.

Unsure why `ab.completed = False` is required for the iOS query but `ab.completed = True` is required for the Android query, and also why "mp3" has anything to do with anything.