### PR TITLE
Disable scheduling in the CODE environment

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -23,6 +23,9 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: ophan-dist
+Conditions:
+  IsProduction:
+    !Equals [!Ref Stage, PROD]
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -146,7 +149,7 @@ Resources:
     Properties:
       Name: !Sub data-lake-alerts-monitoring-schedule-${Stage}
       ScheduleExpression: cron(0 6 ? * MON-FRI *)
-      State: ENABLED
+      State: !If [IsProduction, ENABLED, DISABLED] # Schedules are disabled in CODE. This allows us to safely test rule creation without wasting money running unnecessary queries
       Targets:
         - Arn: !GetAtt Lambda.Arn
           Id: ios-friction-screen-scheduler


### PR DESCRIPTION
I've just created a `PROD` environment, but I don't want to run twice as many queries unnecessarily. Consequently this PR disables the scheduled event in `CODE`.

I still think it's important to have a `CODE` environment of some sort, so that CloudFormation changes can be properly tested. This is the best compromise I could think of at the moment.