### PR TITLE
Improve additional alert information (and make it mandatory)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ libraryDependencies ++= Seq(
   "com.gu" %% "anghammarad-client" % "1.0.4",
   "org.slf4j" % "slf4j-api" % "1.7.26",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
-  "com.amazonaws" % "aws-java-sdk-athena" % "1.11.577"
+  "com.amazonaws" % "aws-java-sdk-athena" % "1.11.577",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/src/main/scala/com/gu/datalakealerts/AlertInformation.scala
+++ b/src/main/scala/com/gu/datalakealerts/AlertInformation.scala
@@ -16,7 +16,7 @@ object AlertInformation {
 
   def describeResults(actualImpressions: Int, expectedImpressions: Int): String = {
     val percentageChangeDescription = describePercentageChange(percentageChange(actualImpressions, expectedImpressions))
-    s"Actual impressions: $actualImpressions | Expected impressions: $expectedImpressions. | $percentageChangeDescription"
+    s"Actual impressions: $actualImpressions | Expected impressions: $expectedImpressions | Percentage: $percentageChangeDescription"
   }
 
 }

--- a/src/main/scala/com/gu/datalakealerts/AlertInformation.scala
+++ b/src/main/scala/com/gu/datalakealerts/AlertInformation.scala
@@ -1,0 +1,23 @@
+package com.gu.datalakealerts
+
+import java.text.NumberFormat
+
+object AlertInformation {
+
+  def percentageChange(actualImpressions: Int, expectedImpressions: Int): BigDecimal = {
+    BigDecimal((actualImpressions.toDouble / expectedImpressions.toDouble) - 1).setScale(2, BigDecimal.RoundingMode.HALF_UP)
+  }
+
+  def describePercentageChange(percentageChange: BigDecimal): String = percentageChange match {
+    case _ if percentageChange > 0 => s"${NumberFormat.getPercentInstance.format(percentageChange)} above the threshold"
+    case _ if percentageChange < 0 => s"${NumberFormat.getPercentInstance.format(-percentageChange)} below the threshold"
+    case _ => s"Threshold was met exactly"
+  }
+
+  def describeResults(actualImpressions: Int, expectedImpressions: Int): String = {
+    val percentageChangeDescription = describePercentageChange(percentageChange(actualImpressions, expectedImpressions))
+    s"Actual impressions: $actualImpressions | Expected impressions: $expectedImpressions. | $percentageChangeDescription"
+  }
+
+}
+

--- a/src/main/scala/com/gu/datalakealerts/Lambda.scala
+++ b/src/main/scala/com/gu/datalakealerts/Lambda.scala
@@ -57,7 +57,7 @@ object Notifications {
 
   val env = Env()
 
-  def alert(featureId: String, executionId: String, message: Option[String], stackForProductionAlerts: Stack) = {
+  def alert(featureId: String, executionId: String, message: String, stackForProductionAlerts: Stack) = {
 
     val stack = env.stage match {
       case "PROD" => stackForProductionAlerts
@@ -66,7 +66,7 @@ object Notifications {
 
     val notificationAttempt = Anghammarad.notify(
       subject = s"Data Lake Monitoring | Check Failed for ${featureId}",
-      message = message.getOrElse(s"Check failed when monitoring ${featureId}"),
+      message = message,
       sourceSystem = "Data Lake Alerts",
       channel = Email,
       target = List(stack),
@@ -106,11 +106,11 @@ object Lambda {
       Notifications.alert(
         featureId = feature.id,
         executionId = queryExecutionId,
-        monitoringResult.additionalDebugInformation,
+        monitoringResult.additionalInformation,
         stackForProductionAlerts = Stack(platform.id) //This stack will be overridden in other environments (to avoid spam)
       )
     } else {
-      logger.info(s"Monitoring ran successfully for ${feature.id}. No problems were detected.")
+      logger.info(s"Monitoring ran successfully for ${feature.id} on ${platform.id}. No problems were detected.\n${monitoringResult.additionalInformation}.")
     }
   }
 

--- a/src/test/scala/com.gu.datalakealerts/AlertInformationTest.scala
+++ b/src/test/scala/com.gu.datalakealerts/AlertInformationTest.scala
@@ -1,0 +1,38 @@
+package com.gu.datalakealerts
+
+import org.scalatest._
+import AlertInformation._
+
+class AlertInformationTest extends FlatSpec {
+
+  "percentageChange" should "correctly calculate the percentage change if the threshold is exceeded" in {
+    val result = percentageChange(actualImpressions = 110, expectedImpressions = 100)
+    assert(result == 0.10)
+  }
+
+  "percentageChange" should "correctly calculate the percentage change if the threshold is not met" in {
+    val result = percentageChange(actualImpressions = 90, expectedImpressions = 100)
+    assert(result == -0.10)
+  }
+
+  "percentageChange" should "correctly identify a case where the threshold is met exactly" in {
+    val result = percentageChange(actualImpressions = 100, expectedImpressions = 100)
+    assert(result == 0)
+  }
+
+  "describePercentageChange" should "accurately describe a case where the threshold is exceeded" in {
+    val description = describePercentageChange(0.10)
+    assert(description == "10% above the threshold")
+  }
+
+  "describePercentageChange" should "accurately describe a case where the threshold is not met" in {
+    val description = describePercentageChange(-0.10)
+    assert(description == "10% below the threshold")
+  }
+
+  "describePercentageChange" should "accurately describe a case where the threshold is met exactly" in {
+    val description = describePercentageChange(0)
+    assert(description == "Threshold was met exactly")
+  }
+
+}


### PR DESCRIPTION
Incorporates some feedback from @alexanderedge and @davidfurey.

- Improves logging in successful case (no alert sent), to increase trust in the monitoring tool! You now get a log line like: `2019-08-14 15:53:33 [run-main-0]  INFO  Lambda$:113 - Monitoring ran successfully for friction_screen on android. No problems were detected.
Actual impressions: 52250 | Expected impressions: 35000 | Percentage: 49% above the threshold.`
- If an alert is sent, includes the amount that we fell below the minimum expected threshold (as a percentage)
- Makes additional alert information mandatory - there's not much value in sending alerts which don't have the required debug info
- Adds a few unit tests