### PR TITLE
Add meta-alerting

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -179,3 +179,21 @@ Resources:
               "featureId": "epic",
               "platformId": "ios"
             }
+
+  DataLakeAlertsFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test
+      AlarmName: Data Lake Alerts Monitoring Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref Lambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching


### PR DESCRIPTION
Prior to this PR, checking the logs was the only way to distinguish between a case where all monitoring checks ran successfully (i.e. no alerts were sent because no alerts should be sent) and the case where this lambda fails (i.e. no alerts were sent because something went wrong). This PR solves that problem by adding alerting for this alerting service.