### PR TITLE
Create different alarm for each stage

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -185,7 +185,7 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test
-      AlarmName: Data Lake Alerts Monitoring Errors
+      AlarmName: !Sub Data Lake Alerts Monitoring Errors in ${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName


### PR DESCRIPTION
I forgot to change the alert name based on the stage, which meant that [this change](https://github.com/guardian/data-lake-alerts/pull/19) couldn't be deployed to `CODE` and `PROD` at the same time 🤦‍♂ 