### PR TITLE
Edit schedule so that monitoring tasks run later

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -148,7 +148,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: !Sub data-lake-alerts-monitoring-schedule-${Stage}
-      ScheduleExpression: cron(0 6 ? * MON-FRI *)
+      ScheduleExpression: cron(0 12 ? * MON-FRI *)
       State: !If [IsProduction, ENABLED, DISABLED] # Schedules are disabled in CODE. This allows us to safely test rule creation without wasting money running unnecessary queries
       Targets:
         - Arn: !GetAtt Lambda.Arn


### PR DESCRIPTION
There have been several occasions in the last few weeks where yesterday's page view data has not been available first thing in the morning.

This is a pain because:

1) we get several false alarms
2) we have to remember to manually re-run each monitoring task once the table has been updated

This PR edits the schedule so that we run our checks later in the day (which affords the Data Tech team some time to fix/re-run failed jobs). It might also be worth adding a check for staleness before running our own queries, but this simple change should mitigate our problems slightly...