### PR TITLE
Decrease expected Olgil epic impressions for iOS

### DIFF
--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -94,7 +94,7 @@ object Features {
             |and ab.name like '%epic%'
             |and ab.completed = False
             |group by 1
-          """.stripMargin, 308658)
+          """.stripMargin, 185000)
       }
     }
   }


### PR DESCRIPTION
Before Braze, we expected around 617315 impressions a day. I think it's around 66% of users that are eligible for Braze (have accepted personalised advertising, and have 'limit ad tracking' turned off), so let's look for around 30% of the original number on Olgil.