### PR TITLE
Disable iOS Braze Epic Monitoring (and enable Android Braze Epic Monitoring)

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -184,7 +184,7 @@ Resources:
           Input: |
             {
               "featureId": "braze_epic",
-              "platformId": "ios"
+              "platformId": "android"
             }
 
   DataLakeAlertsFailureAlarm:


### PR DESCRIPTION
We've temporarily stopped serving epics via Braze on iOS, so I'm disabling this monitoring task for now (to avoid noise / false alarms).

As it happens, there's a [limitation](https://github.com/guardian/data-lake-alerts/pull/26#pullrequestreview-293047561) which was preventing us from performing the same monitoring task for Android. Since there's now a free target slot, we might as well start running the Android version of the check instead of removing the target completely. 

It will be trivial to reenable the iOS version of the check when necessary (if my refactor to allow more targets is complete, it will 'just work'; if not we can temporarily add a second event rule to workaround the limitation).