### PR TITLE
Add scheduler lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export AWS_REGION=eu-west-1
 ```
 
 1. Obtain `developerPlayground` and `ophan` Janus credentials.
-1. Run `sbt "run my_platform my_feature"` (passing in the relevant `Platform` and `Feature` ids).
+1. Run `sbt "runMain com.gu.datalakealerts.TestWorker my_platform my_feature"` (passing in the relevant `Platform` and `Feature` ids).
 
 Note that when running locally or in the `CODE` environment all alerts will be sent to the `anghammarad.test.alerts` Google Group 
 (instead of the team who maintains the specified production stack).

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -115,10 +115,30 @@ Resources:
               Resource:
                 - arn:aws:s3:::aws-athena-query-results-*/primary/*
 
-  Lambda:
+  DataLakeAlertsSchedulerLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${App}-${Stage}
+      FunctionName: !Sub ${App}-scheduler-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Schedules invocations of the DataLakeAlertsWorkerLambda
+      Handler: com.gu.datalakealerts.SchedulerLambda::handler
+      MemorySize: 1536
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 60
+
+  DataLakeAlertsWorkerLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${App}-worker-${Stage}
       Code:
         S3Bucket:
           Ref: DeployBucket
@@ -130,7 +150,7 @@ Resources:
           App: !Ref App
           SnsTopicForAlerts: !Ref SnsTopicForAlerts
       Description: Query the data lake and alert if thresholds are breached
-      Handler: com.gu.datalakealerts.Lambda::handler
+      Handler: com.gu.datalakealerts.WorkerLambda::handler
       MemorySize: 1536
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
@@ -140,7 +160,7 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt Lambda.Arn
+      FunctionName: !GetAtt DataLakeAlertsWorkerLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt MonitoringSchedule.Arn
 
@@ -151,35 +171,35 @@ Resources:
       ScheduleExpression: cron(0 12 ? * MON-FRI *)
       State: !If [IsProduction, ENABLED, DISABLED] # Schedules are disabled in CODE. This allows us to safely test rule creation without wasting money running unnecessary queries
       Targets:
-        - Arn: !GetAtt Lambda.Arn
+        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
           Id: ios-friction-screen-scheduler
           Input: |
             {
               "featureId": "friction_screen",
               "platformId": "ios"
             }
-        - Arn: !GetAtt Lambda.Arn
+        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
           Id: android-friction-screen-scheduler
           Input: |
             {
               "featureId": "friction_screen",
               "platformId": "android"
             }
-        - Arn: !GetAtt Lambda.Arn
+        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
           Id: android-olgil-epic-scheduler
           Input: |
             {
               "featureId": "olgil_epic",
               "platformId": "android"
             }
-        - Arn: !GetAtt Lambda.Arn
+        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
           Id: ios-olgil-epic-scheduler
           Input: |
             {
               "featureId": "olgil_epic",
               "platformId": "ios"
             }
-        - Arn: !GetAtt Lambda.Arn
+        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
           Id: ios-braze-epic-scheduler
           Input: |
             {
@@ -196,7 +216,7 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Ref Lambda
+          Value: !Ref DataLakeAlertsWorkerLambda
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,9 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: ophan-dist
-      functionNames: [data-lake-alerts-]
+      functionNames:
+        - "data-lake-alerts-worker-"
+        - "data-lake-alerts-scheduler-"
       fileName: data-lake-alerts.jar
       prefixStack: false
     dependencies: [data-lake-alerts-cfn]

--- a/src/main/scala/com/gu/datalakealerts/SchedulerLambda.scala
+++ b/src/main/scala/com/gu/datalakealerts/SchedulerLambda.scala
@@ -1,0 +1,37 @@
+package com.gu.datalakealerts
+
+import com.amazonaws.services.lambda.runtime.Context
+import org.slf4j.{ Logger, LoggerFactory }
+
+case class SchedulerEnv(app: String, stack: String, stage: String) {
+  override def toString: String = s"App: $app, Stack: $stack, Stage: $stage\n"
+}
+
+object SchedulerEnv {
+  def apply(): SchedulerEnv = SchedulerEnv(
+    Option(System.getenv("App")).getOrElse("DEV"),
+    Option(System.getenv("Stack")).getOrElse("DEV"),
+    Option(System.getenv("Stage")).getOrElse("DEV"))
+}
+
+object SchedulerLambda {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def handler(lambdaInput: LambdaInput, context: Context): Unit = {
+    val env = SchedulerEnv()
+    logger.info(s"Starting $env")
+    process(env)
+  }
+
+  def process(env: SchedulerEnv): Unit = {
+    logger.info(s"Running Data Lake Alerts scheduler...")
+  }
+
+}
+
+object TestScheduler {
+  def main(args: Array[String]): Unit = {
+    SchedulerLambda.process(SchedulerEnv())
+  }
+}


### PR DESCRIPTION
Unfortunately there is a [5 target limit per CloudWatch Event Rule](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudwatch_events), which means that we need a new approach for scheduling monitoring tasks.

The approach I'm working on will be something like this:

![image](https://user-images.githubusercontent.com/19384074/65757644-7bd7a580-e10f-11e9-8ce0-c5ed49be9a2f.png)

This PR is the first part of that restructure. It adds a very basic version of new Scheduler Lambda (which doesn't do any real work yet) and refactors the existing Worker Lambda accordingly. 

For now the scheduling is unchanged and the worker is still invoked via the scheduled event (this will be changed in a subsequent PR).