### PR TITLE
Allow scheduler to invoke the worker 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.amazonaws" % "aws-java-sdk-lambda" % "1.11.639",
   "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.604",
   "com.gu" %% "anghammarad-client" % "1.0.4",
   "org.slf4j" % "slf4j-api" % "1.7.26",

--- a/src/main/scala/com/gu/datalakealerts/Athena.scala
+++ b/src/main/scala/com/gu/datalakealerts/Athena.scala
@@ -13,7 +13,7 @@ object Athena {
 
   val client: AmazonAthena = AmazonAthenaClient
     .builder()
-    .withCredentials(AwsCredentials.athenaCredentials)
+    .withCredentials(AwsCredentials.ophanCredentials)
     .build()
 
   def startQuery(monitoringQuery: MonitoringQuery): StartQueryExecutionResult = {

--- a/src/main/scala/com/gu/datalakealerts/AwsCredentials.scala
+++ b/src/main/scala/com/gu/datalakealerts/AwsCredentials.scala
@@ -5,11 +5,11 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
 object AwsCredentials {
 
-  val athenaCredentials = new AWSCredentialsProviderChain(
+  val ophanCredentials = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("ophan"),
     new EnvironmentVariableCredentialsProvider())
 
-  val notificationCredentials = new AWSCredentialsProviderChain(
+  val developerPlaygroundCredentials = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("developerPlayground"),
     new EnvironmentVariableCredentialsProvider())
 

--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -9,7 +9,7 @@ object Features {
 
   val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, OlgilEpic, BrazeEpic)
 
-  val yesterday: LocalDate = LocalDate.now().minusDays(1)
+  def yesterday: LocalDate = LocalDate.now().minusDays(1)
 
   def featureToMonitor(featureId: String): Feature = {
     allFeaturesWithMonitoring

--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -7,8 +7,9 @@ import com.gu.datalakealerts.Platforms.{ Android, iOS, Platform }
 
 object Features {
 
-  val yesterday: LocalDate = LocalDate.now().minusDays(1)
   val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, OlgilEpic, BrazeEpic)
+
+  val yesterday: LocalDate = LocalDate.now().minusDays(1)
 
   def featureToMonitor(featureId: String): Feature = {
     allFeaturesWithMonitoring
@@ -21,6 +22,7 @@ object Features {
 
   sealed trait Feature {
     val id: String
+    val platformsToMonitor: List[Platform] = List(iOS, Android)
     def monitoringQuery(platform: Platform): MonitoringQuery
     def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult
   }

--- a/src/main/scala/com/gu/datalakealerts/InvokeWorker.scala
+++ b/src/main/scala/com/gu/datalakealerts/InvokeWorker.scala
@@ -1,0 +1,30 @@
+package com.gu.datalakealerts
+
+import com.amazonaws.services.lambda.AWSLambdaClient
+import com.amazonaws.services.lambda.model.{ InvocationType, InvokeRequest }
+
+object InvokeWorker {
+
+  val client = AWSLambdaClient
+    .builder()
+    .withCredentials(AwsCredentials.ophanCredentials)
+    .build()
+
+  def run(monitoringEvent: MonitoringEvent, stage: String) = {
+
+    val functionToInvoke = if (stage.equals("PROD")) {
+      "data-lake-alerts-worker-PROD"
+    } else {
+      "data-lake-alerts-worker-CODE"
+    }
+
+    val request: InvokeRequest = new InvokeRequest()
+      .withFunctionName(functionToInvoke)
+      .withInvocationType(InvocationType.Event) // This is asynchronous, and gives us retries for free. See: https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax
+      .withPayload(monitoringEvent.toJson)
+
+    client.invoke(request)
+
+  }
+
+}

--- a/src/main/scala/com/gu/datalakealerts/InvokeWorker.scala
+++ b/src/main/scala/com/gu/datalakealerts/InvokeWorker.scala
@@ -1,9 +1,14 @@
 package com.gu.datalakealerts
 
 import com.amazonaws.services.lambda.AWSLambdaClient
-import com.amazonaws.services.lambda.model.{ InvocationType, InvokeRequest }
+import com.amazonaws.services.lambda.model.{ InvocationType, InvokeRequest, InvokeResult }
+import org.slf4j.{ Logger, LoggerFactory }
+
+import scala.util.{ Failure, Success, Try }
 
 object InvokeWorker {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val client = AWSLambdaClient
     .builder()
@@ -23,7 +28,16 @@ object InvokeWorker {
       .withInvocationType(InvocationType.Event) // This is asynchronous, and gives us retries for free. See: https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax
       .withPayload(monitoringEvent.toJson)
 
-    client.invoke(request)
+    Try { client.invoke(request) } match {
+      case Success(invokeResult: InvokeResult) =>
+        val invocationWasSuccessful = invokeResult.getStatusCode >= 200 && invokeResult.getStatusCode < 300
+        if (invocationWasSuccessful) {
+          logger.info(s"Successfully triggered worker lambda with event: $monitoringEvent")
+        } else {
+          logger.error(s"Failed to invoke lambda for event ${monitoringEvent} due to ${invokeResult.getFunctionError}")
+        }
+      case Failure(throwable: Throwable) => logger.error(s"Failed to invoke lambda for $monitoringEvent due to $throwable")
+    }
 
   }
 

--- a/src/main/scala/com/gu/datalakealerts/MonitoringEvent.scala
+++ b/src/main/scala/com/gu/datalakealerts/MonitoringEvent.scala
@@ -1,0 +1,12 @@
+package com.gu.datalakealerts
+
+case class MonitoringEvent(feature: Features.Feature, platform: Platforms.Platform) {
+
+  def toJson = s"""
+     |{
+     |  "featureId": "${feature.id}",
+     |  "platformId": "${platform.id}"
+     |}
+   |""".stripMargin
+
+}

--- a/src/main/scala/com/gu/datalakealerts/SchedulerLambda.scala
+++ b/src/main/scala/com/gu/datalakealerts/SchedulerLambda.scala
@@ -3,8 +3,6 @@ package com.gu.datalakealerts
 import com.amazonaws.services.lambda.runtime.Context
 import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.util.Try
-
 case class SchedulerEnv(app: String, stack: String, stage: String) {
   override def toString: String = s"App: $app, Stack: $stack, Stage: $stage\n"
 }
@@ -36,7 +34,7 @@ object SchedulerLambda {
     } else {
       allMonitoringEvents.map { monitoringEvent =>
         logger.info(s"Invoking worker lambda for monitoring event: $monitoringEvent")
-        Try { InvokeWorker.run(monitoringEvent, env.stage) }
+        InvokeWorker.run(monitoringEvent, env.stage)
       }
     }
   }

--- a/src/main/scala/com/gu/datalakealerts/WorkerLambda.scala
+++ b/src/main/scala/com/gu/datalakealerts/WorkerLambda.scala
@@ -36,7 +36,7 @@ object WorkerEnv {
   // Only used when running locally
   lazy val ssmClient = AWSSimpleSystemsManagementClientBuilder
     .standard()
-    .withCredentials(AwsCredentials.notificationCredentials)
+    .withCredentials(AwsCredentials.developerPlaygroundCredentials)
     .build()
 
   // Only used when running locally
@@ -74,7 +74,7 @@ object Notifications {
         cta = "View Query Results [Requires Ophan AWS Console Access]",
         url = s"https://eu-west-1.console.aws.amazon.com/athena/home?region=eu-west-1#query/history/${executionId}")),
       topicArn = env.snsTopicForAlerts,
-      client = AWS.snsClient(AwsCredentials.notificationCredentials))
+      client = AWS.snsClient(AwsCredentials.developerPlaygroundCredentials))
 
     Try(Await.result(notificationAttempt, 10.seconds)) match {
       case Success(_) => logger.info("Sent notification via Anghammarad")


### PR DESCRIPTION
Continues the work started in: https://github.com/guardian/data-lake-alerts/pull/28.

Note that the final part of this work (i.e. updating the CloudFormation so that the scheduler is invoked, instead of the worker) will follow in another PR.