### PR TITLE
Trigger the Scheduler Lambda via the CloudWatch Event Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ a different table, you'll need to add further permissions to the Cloudformation 
     1. The Athena pricing model is based on data scanned, so try not to scan more data than necessary.
 1. Add `MyFeature extends Feature { ??? }` to the `Features` object. You will need to provide:
     1. A feature id (used when triggering the lambda)
-    1. A function which returns your query (to be run by Athena).
+    1. A list of platforms which the feature is relevant for (defaults to iOS and Android)
+    1. A function which returns your query (to be run by Athena)
     1. A function which performs a check on the query's results and (optionally) 
     additional debug information which will be included in the alert in the event of a failure.
 1. Add your feature to `allFeaturesWithMonitoring` (also in the `Features` object).

--- a/README.md
+++ b/README.md
@@ -41,23 +41,10 @@ Note that when running locally or in the `CODE` environment all alerts will be s
 
 This allows you to send test alerts in these environments without spamming your team.
 
-### Triggering the monitoring task
+### Monitoring Schedule
 
-The simplest option is to run the monitoring task on a daily basis, using a Scheduled Event.
+Monitoring checks run at [12:00 UTC every weekday](https://github.com/guardian/data-lake-alerts/blob/master/cfn.yaml#L171). 
+To confirm that monitoring has been scheduled correctly for your feature:
 
-1. Add a new Target to the `MonitoringSchedule` (in cfn.yaml). It should look something like this:
-    
-    ```
-    - Arn: !GetAtt Lambda.Arn
-      Id: ios-friction-screen-scheduler
-      Input: |
-        {
-          "featureId": "friction_screen",
-          "platformId": "ios"
-        }
-    ```
-    
-However, as this monitoring task runs as a lambda function, it's possible to use a different trigger
-event (e.g. another lambda) to invoke the function with the relevant input event.
-
-You should deploy this change to `CODE` to ensure that your Cloudformation changes are valid.
+1. Run `sbt "runMain com.gu.datalakealerts.TestScheduler"`
+    1. Confirm that your feature (and platform) are listed in the output.

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -171,48 +171,33 @@ Resources:
       ScheduleExpression: cron(0 12 ? * MON-FRI *)
       State: !If [IsProduction, ENABLED, DISABLED] # Schedules are disabled in CODE. This allows us to safely test rule creation without wasting money running unnecessary queries
       Targets:
-        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
-          Id: ios-friction-screen-scheduler
-          Input: |
-            {
-              "featureId": "friction_screen",
-              "platformId": "ios"
-            }
-        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
-          Id: android-friction-screen-scheduler
-          Input: |
-            {
-              "featureId": "friction_screen",
-              "platformId": "android"
-            }
-        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
-          Id: android-olgil-epic-scheduler
-          Input: |
-            {
-              "featureId": "olgil_epic",
-              "platformId": "android"
-            }
-        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
-          Id: ios-olgil-epic-scheduler
-          Input: |
-            {
-              "featureId": "olgil_epic",
-              "platformId": "ios"
-            }
-        - Arn: !GetAtt DataLakeAlertsWorkerLambda.Arn
-          Id: ios-braze-epic-scheduler
-          Input: |
-            {
-              "featureId": "braze_epic",
-              "platformId": "android"
-            }
+        - Arn: !GetAtt DataLakeAlertsSchedulerLambda.Arn
+          Id: data-lake-alerts-schedule
 
-  DataLakeAlertsFailureAlarm:
+  DataLakeAlertsSchedulerAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test
-      AlarmName: !Sub Data Lake Alerts Monitoring Errors in ${Stage}
+      AlarmName: !Sub Data Lake Alerts Monitoring Errors (Scheduler Lambda) in ${Stage}
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref DataLakeAlertsSchedulerLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  DataLakeAlertsWorkerAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-test
+      AlarmName: !Sub Data Lake Alerts Monitoring Errors (Worker Lambda) in ${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -160,7 +160,7 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt DataLakeAlertsWorkerLambda.Arn
+      FunctionName: !GetAtt DataLakeAlertsSchedulerLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt MonitoringSchedule.Arn
 


### PR DESCRIPTION
This is the final part of a restructure (see also https://github.com/guardian/data-lake-alerts/pull/28 and https://github.com/guardian/data-lake-alerts/pull/29) which moves us to this architecture:

![image](https://user-images.githubusercontent.com/19384074/65883398-d92d5a00-e38e-11e9-83a2-cdcf53a31d30.png)

Although this work was primarily undertaken to work around an AWS limitation (5 targets per rule), it has also made it easier to add new monitoring tasks. 

The Scheduler Lambda now automatically figures out the input JSON for a feature, meaning that no CFN changes are required when adding new monitoring.