### PR TITLE
Increase timeout for worker lambda

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -154,7 +154,7 @@ Resources:
       MemorySize: 1536
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 180
+      Timeout: 900
 
   MonitoringSchedulePermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
Now that we are submitting more queries to AWS concurrently, the worker lambda is often timing out before the results of its query are available. Although a query is listed as `RUNNING` straight after submission:

> RUNNING indicates that the query has been submitted to the service, and Athena will execute the query *as soon as resources are available*.

If AWS isn't able to execute all of the queries within 180 seconds, we see alerts due to timeouts (which are annoying). These timeouts currently result in the query being automatically retried by AWS (which is wasteful, as we are often paying to run the same query more than once).

This PR is a short term measure to buy us some time, and avoid the alerts/retries mentioned above. The proper solution to this problem requires a little more thought (since we probably need to maintain state ourselves) and will be addressed in a subsequent PR.