### PR TITLE
Remove duplication when checking results

### DIFF
--- a/src/main/scala/com/gu/datalakealerts/Athena.scala
+++ b/src/main/scala/com/gu/datalakealerts/Athena.scala
@@ -1,11 +1,9 @@
 package com.gu.datalakealerts
 
 import com.amazonaws.services.athena.{ AmazonAthena, AmazonAthenaClient }
-import com.amazonaws.services.athena.model.{ GetQueryExecutionRequest, GetQueryResultsRequest, ResultConfiguration, ResultSet, StartQueryExecutionRequest, StartQueryExecutionResult }
+import com.amazonaws.services.athena.model.{ GetQueryExecutionRequest, GetQueryResultsRequest, ResultSet, StartQueryExecutionRequest, StartQueryExecutionResult }
 import com.gu.datalakealerts.Features.MonitoringQuery
 import org.slf4j.{ Logger, LoggerFactory }
-
-import scala.collection.JavaConverters._
 
 object Athena {
 
@@ -44,21 +42,6 @@ object Athena {
     val retrieveQueryRequest: GetQueryResultsRequest = new GetQueryResultsRequest()
       .withQueryExecutionId(queryExecutionId)
     client.getQueryResults(retrieveQueryRequest).getResultSet
-  }
-
-}
-
-object ImpressionCounts {
-
-  case class VersionWithImpressionCount(versionNumber: String, impressions: Int) {
-    def summary = s"$versionNumber: $impressions"
-  }
-
-  def getImpressionCounts(result: ResultSet): List[VersionWithImpressionCount] = {
-    result.getRows.asScala.toList.drop(1).map { row =>
-      val datum = row.getData
-      VersionWithImpressionCount(datum.get(0).getVarCharValue, datum.get(1).getVarCharValue.toInt)
-    }
   }
 
 }

--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -59,12 +59,12 @@ object Features {
   }
 
   case object OlgilEpic extends Feature {
-    override val id = "olgil_epic"
+    val id = "olgil_epic"
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
       ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
-    override def monitoringQuery(platform: Platform): MonitoringQuery = {
+    def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
         case Android =>
           MonitoringQuery(s"""
@@ -95,12 +95,12 @@ object Features {
   }
 
   case object BrazeEpic extends Feature {
-    override val id = "braze_epic"
+    val id = "braze_epic"
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
       ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
-    override def monitoringQuery(platform: Platform): MonitoringQuery = {
+    def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
         case Android =>
           MonitoringQuery(s"""
@@ -128,13 +128,13 @@ object Features {
     }
   }
   case object OlgilBanner extends Feature {
-    override val id = "olgil_banner"
+    val id = "olgil_banner"
     override val platformsToMonitor = List(iOS)
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
       ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
-    override def monitoringQuery(platform: Platform): MonitoringQuery = {
+    def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
         case iOS =>
           MonitoringQuery(s"""
@@ -155,13 +155,13 @@ object Features {
   }
 
   case object BrazeBanner extends Feature {
-    override val id = "braze_banner"
+    val id = "braze_banner"
     override val platformsToMonitor = List(iOS)
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
       ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
-    override def monitoringQuery(platform: Platform): MonitoringQuery = {
+    def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
         case iOS =>
           MonitoringQuery(s"""

--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -3,7 +3,8 @@ package com.gu.datalakealerts
 import java.time.LocalDate
 
 import com.amazonaws.services.athena.model.ResultSet
-import com.gu.datalakealerts.Platforms.{ Android, iOS, Platform }
+import com.gu.datalakealerts.Platforms.{ Android, Platform, iOS }
+import com.gu.datalakealerts.apps.ResultHandler
 
 object Features {
 
@@ -52,24 +53,16 @@ object Features {
 
     }
 
-    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
-      val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
-      val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
-      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-      MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
-    }
+    def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+      ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
   }
 
   case object OlgilEpic extends Feature {
     override val id = "olgil_epic"
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
-      val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
-      val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
-      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-      MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
-    }
+    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+      ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
     override def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
@@ -104,12 +97,8 @@ object Features {
   case object BrazeEpic extends Feature {
     override val id = "braze_epic"
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
-      val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
-      val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
-      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-      MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
-    }
+    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+      ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
     override def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
@@ -142,12 +131,8 @@ object Features {
     override val id = "olgil_banner"
     override val platformsToMonitor = List(iOS)
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
-      val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
-      val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
-      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-      MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
-    }
+    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+      ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
     override def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {
@@ -173,12 +158,8 @@ object Features {
     override val id = "braze_banner"
     override val platformsToMonitor = List(iOS)
 
-    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
-      val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
-      val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
-      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-      MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
-    }
+    override def monitoringQueryResult(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult =
+      ResultHandler.checkThresholdMetAcrossAppVersions(resultSet, minimumImpressionsThreshold)
 
     override def monitoringQuery(platform: Platform): MonitoringQuery = {
       platform match {

--- a/src/main/scala/com/gu/datalakealerts/apps/ResultHandler.scala
+++ b/src/main/scala/com/gu/datalakealerts/apps/ResultHandler.scala
@@ -1,0 +1,32 @@
+package com.gu.datalakealerts.apps
+
+import com.amazonaws.services.athena.model.ResultSet
+import com.gu.datalakealerts.AlertInformation
+import com.gu.datalakealerts.Features.MonitoringQueryResult
+import scala.collection.JavaConverters._
+
+object ResultHandler {
+
+  object ImpressionCounts {
+
+    case class VersionWithImpressionCount(versionNumber: String, impressions: Int) {
+      def summary = s"$versionNumber: $impressions"
+    }
+
+    def getImpressionCounts(result: ResultSet): List[VersionWithImpressionCount] = {
+      result.getRows.asScala.toList.drop(1).map { row =>
+        val datum = row.getData
+        VersionWithImpressionCount(datum.get(0).getVarCharValue, datum.get(1).getVarCharValue.toInt)
+      }
+    }
+
+  }
+
+  def checkThresholdMetAcrossAppVersions(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
+    val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
+    val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
+    val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
+    MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
+  }
+
+}


### PR DESCRIPTION
This [commit](https://github.com/guardian/data-lake-alerts/commit/14746e47928572cb6c4bd7ad934d8aa4f956bcd4) addresses [this feedback](https://github.com/guardian/data-lake-alerts/pull/32#discussion_r337900965).

This [commit](https://github.com/guardian/data-lake-alerts/commit/509db3c3280b72acadabcfb90dd9cb37596ba099), removes some unnecessary usages of `override`. 
