### PR TITLE
GLA-1579-Braze-banner-prod-monitoring

### DIFF
--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -8,7 +8,7 @@ import com.gu.datalakealerts.apps.ResultHandler
 
 object Features {
 
-  val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, OlgilEpic, BrazeEpic, OlgilBanner)
+  val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, OlgilEpic, BrazeEpic, OlgilBanner, BrazeBanner)
 
   def yesterday: LocalDate = LocalDate.now().minusDays(1)
 
@@ -147,7 +147,7 @@ object Features {
             |and ab.name like '%banner%'
             |and ab.completed = False
             |group by 1
-          """.stripMargin, 33280)
+          """.stripMargin, 17038)
         case _ => throw new RuntimeException("Only iOS platform is supported.")
 
       }
@@ -173,7 +173,7 @@ object Features {
             |and c.component.type = 'APP_ENGAGEMENT_BANNER'
             |and c.action = 'VIEW'
             |group by 1
-          """.stripMargin, 0)
+          """.stripMargin, 2893)
         case _ => throw new RuntimeException("Only iOS platform is supported.")
       }
     }


### PR DESCRIPTION
I ran queries on the data lake to see how many impressions were made yesterday for the Braze Banner and Olgil Banner. I found **5786 Braze banner** and **34077 Olgil banner** impressions and I have divided set the threshold as half of these. 

It does seem like a drop in the number of impressions compared to what was previously set as the Olgil banner impression level. 