### PR TITLE
Drop expected friction screen impressions for Android

### DIFF
--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -45,7 +45,7 @@ object Features {
         |group by 1""".stripMargin
 
       val minimumImpressionsThreshold = platform match {
-        case Android => 35000
+        case Android => 10000
         case iOS => 40000
       }
 


### PR DESCRIPTION
Since moving the logic for displaying a friction screen into Braze, friction screen impressions are no longer evenly distributed:

![image](https://user-images.githubusercontent.com/19384074/71362352-b2e21980-258d-11ea-9387-1f9f770daf5c.png)

To prevent lots of false alarms, I'm dropping the expected threshold until the distribution levels out again. I'll create a card to remind us to revisit this in 2020.