### PR TITLE
Add support for running multiple checks against a single query

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ a different table, you'll need to add further permissions to the Cloudformation 
 
 1. Write your query and test it using Athena. 
     1. The Athena pricing model is based on data scanned, so try not to scan more data than necessary.
-1. Add `MyFeature extends Feature { ??? }` to the `Features` object. You will need to provide:
+1. Add `case object MyFeature extends Feature { ??? }` to the `Features` object. You will need to provide:
     1. A feature id (used when triggering the lambda)
     1. A list of platforms which the feature is relevant for (defaults to iOS and Android)
-    1. A function which returns your query (to be run by Athena)
-    1. A function which performs a check on the query's results and (optionally) 
-    additional debug information which will be included in the alert in the event of a failure.
+    1. A function which returns your query (to be run by Athena) and a list of checks to run when the query completes
 1. Add your feature to `allFeaturesWithMonitoring` (also in the `Features` object).
 
 ### Testing your changes

--- a/src/main/scala/com/gu/datalakealerts/Checks.scala
+++ b/src/main/scala/com/gu/datalakealerts/Checks.scala
@@ -21,7 +21,7 @@ object Checks {
     def checkThresholdMetAcrossAppVersions(allVersionWithImpressionCounts: List[VersionWithImpressionCount], minimumImpressionsThreshold: Int): IndividualResult = {
       val totalImpressions = ImpressionCounts.getTotalImpressions(allVersionWithImpressionCounts)
       val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-      IndividualResult(resultIsAcceptable, "MinimumThresholdIsGreaterThan", ResultInformation.describeResults(totalImpressions, expectedImpressions))
+      IndividualResult(resultIsAcceptable, "TotalImpressionsIsGreaterThan", ResultInformation.describeResults(totalImpressions, expectedImpressions))
     }
   }
 

--- a/src/main/scala/com/gu/datalakealerts/Checks.scala
+++ b/src/main/scala/com/gu/datalakealerts/Checks.scala
@@ -1,0 +1,32 @@
+package com.gu.datalakealerts
+
+import com.gu.datalakealerts.apps.ResultHandler.ImpressionCounts
+import com.gu.datalakealerts.apps.ResultHandler.ImpressionCounts.VersionWithImpressionCount
+
+object Checks {
+
+  case class IndividualResult(resultIsAcceptable: Boolean, checkName: String, resultInformation: String)
+
+  def summariseResults(results: List[IndividualResult]): String = {
+    results.map(result => s"${result.checkName}: ${result.resultInformation}").mkString("\n")
+  }
+
+  def messageFromFailures(failedChecks: List[IndividualResult]): String = {
+    "The following checks failed:\n\n" + s"${summariseResults(failedChecks)}"
+  }
+
+  sealed trait Check
+
+  case class TotalImpressionsIsGreaterThan(expectedImpressions: Int) extends Check {
+    def checkThresholdMetAcrossAppVersions(allVersionWithImpressionCounts: List[VersionWithImpressionCount], minimumImpressionsThreshold: Int): IndividualResult = {
+      val totalImpressions = ImpressionCounts.getTotalImpressions(allVersionWithImpressionCounts)
+      val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
+      IndividualResult(resultIsAcceptable, "MinimumThresholdIsGreaterThan", ResultInformation.describeResults(totalImpressions, expectedImpressions))
+    }
+  }
+
+  def performChecks(allVersionsWithImpressionCounts: List[VersionWithImpressionCount], checks: List[Check]): List[IndividualResult] = checks.map {
+    case check @ TotalImpressionsIsGreaterThan(expectedImpressions) => check.checkThresholdMetAcrossAppVersions(allVersionsWithImpressionCounts, expectedImpressions)
+  }
+
+}

--- a/src/main/scala/com/gu/datalakealerts/Platforms.scala
+++ b/src/main/scala/com/gu/datalakealerts/Platforms.scala
@@ -4,12 +4,12 @@ object Platforms {
 
   sealed trait Platform { val id: String }
   case object Android extends Platform { val id = "android" }
-  case object iOS extends Platform { val id = "ios" }
+  case object Ios extends Platform { val id = "ios" }
 
   def platformToMonitor(platformId: String): Platform = platformId match {
     case Android.id => Android
-    case iOS.id => iOS
-    case _ => throw new RuntimeException(s"Invalid platform specified: platform must be ${Android.id} or ${iOS.id}")
+    case Ios.id => Ios
+    case _ => throw new RuntimeException(s"Invalid platform specified: platform must be ${Android.id} or ${Ios.id}")
   }
 
 }

--- a/src/main/scala/com/gu/datalakealerts/ResultInformation.scala
+++ b/src/main/scala/com/gu/datalakealerts/ResultInformation.scala
@@ -2,7 +2,7 @@ package com.gu.datalakealerts
 
 import java.text.NumberFormat
 
-object AlertInformation {
+object ResultInformation {
 
   def percentageChange(actualImpressions: Int, expectedImpressions: Int): BigDecimal = {
     BigDecimal((actualImpressions.toDouble / expectedImpressions.toDouble) - 1).setScale(2, BigDecimal.RoundingMode.HALF_UP)

--- a/src/main/scala/com/gu/datalakealerts/apps/ResultHandler.scala
+++ b/src/main/scala/com/gu/datalakealerts/apps/ResultHandler.scala
@@ -1,8 +1,7 @@
 package com.gu.datalakealerts.apps
 
 import com.amazonaws.services.athena.model.ResultSet
-import com.gu.datalakealerts.AlertInformation
-import com.gu.datalakealerts.Features.MonitoringQueryResult
+
 import scala.collection.JavaConverters._
 
 object ResultHandler {
@@ -20,13 +19,10 @@ object ResultHandler {
       }
     }
 
-  }
+    def getTotalImpressions(allVersionWithImpressionCounts: List[VersionWithImpressionCount]): Int = {
+      allVersionWithImpressionCounts.map(_.impressions).sum
+    }
 
-  def checkThresholdMetAcrossAppVersions(resultSet: ResultSet, minimumImpressionsThreshold: Int): MonitoringQueryResult = {
-    val impressionCountsByAppVersion = ImpressionCounts.getImpressionCounts(resultSet)
-    val totalImpressions = impressionCountsByAppVersion.map(_.impressions).sum
-    val resultIsAcceptable = totalImpressions > minimumImpressionsThreshold
-    MonitoringQueryResult(resultIsAcceptable, AlertInformation.describeResults(totalImpressions, minimumImpressionsThreshold))
   }
 
 }

--- a/src/test/scala/com.gu.datalakealerts/ResultInformationTest.scala
+++ b/src/test/scala/com.gu.datalakealerts/ResultInformationTest.scala
@@ -1,9 +1,9 @@
 package com.gu.datalakealerts
 
 import org.scalatest._
-import AlertInformation._
+import ResultInformation._
 
-class AlertInformationTest extends FlatSpec {
+class ResultInformationTest extends FlatSpec {
 
   "percentageChange" should "correctly calculate the percentage change if the threshold is exceeded" in {
     val result = percentageChange(actualImpressions = 110, expectedImpressions = 100)


### PR DESCRIPTION
This PR allows us to run multiple checks against the results of a single query. This means that we can run additional checks (e.g. confirming that things still work as expected on the [most recent beta versions](https://mobile.guardianapis.com/static/reserved-paths/ios-live-app/recent-beta-releases.json)), without duplicating lots of code. It could also help us to save [money](https://aws.amazon.com/athena/pricing/), as we can now run a single Athena query and perform multiple checks against its results.