### PR TITLE
Add support for new friction screen rules

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -199,7 +199,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: !Sub data-lake-alerts-monitoring-schedule-${Stage}
-      ScheduleExpression: cron(0 12 ? * MON-FRI *)
+      ScheduleExpression: cron(0 12 * * ? *)
       State: !If [IsProduction, ENABLED, DISABLED] # Schedules are disabled in CODE. This allows us to safely test rule creation without wasting money running unnecessary queries
       Targets:
         - Arn: !GetAtt DataLakeAlertsSchedulerLambda.Arn


### PR DESCRIPTION
Until now all checks have assumed that the day of the week has no impact on the expected number of impressions. Customer Optimisation have changed the rules for the friction screen, which means this assumption is no longer valid.

Because of the aforementioned assumption, we didn't previously run checks over the weekend (prior to this PR the numbers for Friday and Saturday were never being checked). Now that Friday and Saturday have special importance, I decided that we ought to be checking the data for those days! This incurs a small cost (because we are running more lambda invocations and more queries against Athena), but I think it's better than missing bugs/config issues which could potentially only affect these days.

I've confirmed that the new cron is correct by deploying to `CODE`:

![image](https://user-images.githubusercontent.com/19384074/79855341-bf9f3e80-83c2-11ea-8931-0343ed9afec2.png)
