### PR TITLE
Fix peak/off-peak handling

### DIFF
--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -46,13 +46,13 @@ object Features {
       // Users with personalised ads disabled will still see friction screens on other days
       val offPeakDays = DayOfWeek.values().toList.diff(peakDays)
 
-      val dayOfWeek = LocalDate.now().getDayOfWeek
+      val dayOfWeekUnderAnalysis = yesterday.getDayOfWeek
 
       val minimumImpressionsThreshold = platform match {
-        case Android if peakDays.contains(dayOfWeek) => 45000
-        case Android if offPeakDays.contains(dayOfWeek) => 4000
-        case Ios if peakDays.contains(dayOfWeek) => 75000
-        case Ios if offPeakDays.contains(dayOfWeek) => 22000
+        case Android if peakDays.contains(dayOfWeekUnderAnalysis) => 45000
+        case Android if offPeakDays.contains(dayOfWeekUnderAnalysis) => 4000
+        case Ios if peakDays.contains(dayOfWeekUnderAnalysis) => 75000
+        case Ios if offPeakDays.contains(dayOfWeekUnderAnalysis) => 22000
       }
 
       val checks: List[Check] = List(TotalImpressionsIsGreaterThan(minimumImpressionsThreshold))


### PR DESCRIPTION
Fixes a bug with https://github.com/guardian/data-lake-alerts/pull/40.

When estimating thresholds, we always need awareness of _yesterday_'s day of the week, not the day of the week at runtime.