### PR TITLE
Remove redundant alerts

### DIFF
--- a/src/main/scala/com/gu/datalakealerts/Features.scala
+++ b/src/main/scala/com/gu/datalakealerts/Features.scala
@@ -1,13 +1,13 @@
 package com.gu.datalakealerts
 
-import java.time.{ DayOfWeek, LocalDate }
+import java.time.LocalDate
 
 import com.gu.datalakealerts.Checks.{ Check, TotalImpressionsIsGreaterThan }
 import com.gu.datalakealerts.Platforms.{ Android, Ios, Platform }
 
 object Features {
 
-  val allFeaturesWithMonitoring: List[Feature] = List(FrictionScreen, OlgilEpic, BrazeEpic, OlgilBanner, BrazeBanner)
+  val allFeaturesWithMonitoring: List[Feature] = List(OlgilEpic, BrazeEpic, OlgilBanner)
 
   def yesterday: LocalDate = LocalDate.now().minusDays(1)
 
@@ -23,44 +23,6 @@ object Features {
     val id: String
     val platformsToMonitor: List[Platform] = List(Ios, Android)
     def monitoringQuery(platform: Platform): MonitoringQuery
-  }
-
-  case object FrictionScreen extends Feature {
-
-    val id = "friction_screen"
-
-    def monitoringQuery(platform: Platform): MonitoringQuery = {
-
-      val query = s"""
-        |select browser_version, count (distinct page_view_id) as friction_screen_impressions
-        |from clean.pageview
-        |cross join unnest (component_events) x (c)
-        |where received_date = date '$yesterday'
-        |and device_type like '%${platform.id.toUpperCase}%'
-        |and c.component.type like '%APP_SCREEN%'
-        |and c.component.campaign_code like '%friction%' and c.component.campaign_code like '%subscription_screen%'
-        |group by 1""".stripMargin
-
-      // Users with personalised ads enabled should now only see the friction screen on Fri/Sat
-      val peakDays = List(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY)
-      // Users with personalised ads disabled will still see friction screens on other days
-      val offPeakDays = DayOfWeek.values().toList.diff(peakDays)
-
-      val dayOfWeekUnderAnalysis = yesterday.getDayOfWeek
-
-      val minimumImpressionsThreshold = platform match {
-        case Android if peakDays.contains(dayOfWeekUnderAnalysis) => 45000
-        case Android if offPeakDays.contains(dayOfWeekUnderAnalysis) => 4000
-        case Ios if peakDays.contains(dayOfWeekUnderAnalysis) => 75000
-        case Ios if offPeakDays.contains(dayOfWeekUnderAnalysis) => 22000
-      }
-
-      val checks: List[Check] = List(TotalImpressionsIsGreaterThan(minimumImpressionsThreshold))
-
-      MonitoringQuery(query, checks)
-
-    }
-
   }
 
   case object OlgilEpic extends Feature {
@@ -158,32 +120,6 @@ object Features {
             |group by 1
           """.stripMargin,
             List(TotalImpressionsIsGreaterThan(17038)))
-        case _ => throw new RuntimeException(s"Only Ios platform is supported for feature: $id.")
-      }
-    }
-  }
-
-  case object BrazeBanner extends Feature {
-
-    val id = "braze_banner"
-
-    override val platformsToMonitor = List(Ios)
-
-    def monitoringQuery(platform: Platform): MonitoringQuery = {
-      platform match {
-        case Ios =>
-          MonitoringQuery(
-            s"""
-            |select browser_version, count (distinct page_view_id)
-            |from clean.pageview 
-            |cross join unnest (component_events) x (c)
-            |where received_date = date '$yesterday'
-            |and device_type like '%IOS%'
-            |and c.component.type = 'APP_ENGAGEMENT_BANNER'
-            |and c.action = 'VIEW'
-            |group by 1
-            """.stripMargin,
-            List(TotalImpressionsIsGreaterThan(2893)))
         case _ => throw new RuntimeException(s"Only Ios platform is supported for feature: $id.")
       }
     }


### PR DESCRIPTION
The Customer Optimisation team are regularly using Braze to test changes to the display rules for the friction screen and the banner. As a result, alerts related to these acquisition channels have become noisy and unreliable. 

Monitoring these acquisition channels is also less important than it was before, because the Customer Optimisation team are regularly using the dashboard to check performance. 

Consequently, this PR removes alerts related to the number of banners/friction screen impressions initiated by Braze.