### PR TITLE
Disable schedule temporarily

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -200,7 +200,7 @@ Resources:
     Properties:
       Name: !Sub data-lake-alerts-monitoring-schedule-${Stage}
       ScheduleExpression: cron(0 12 * * ? *)
-      State: !If [IsProduction, ENABLED, DISABLED] # Schedules are disabled in CODE. This allows us to safely test rule creation without wasting money running unnecessary queries
+      State: DISABLED # Schedules are temporarily disabled due to recent Data Lake unreliability
       Targets:
         - Arn: !GetAtt DataLakeAlertsSchedulerLambda.Arn
           Id: data-lake-alerts-schedule


### PR DESCRIPTION
There have been too many false alarms from this service recently. 

I'm disabling these alerts until I have time to make the necessary changes to prevent regular false alarms from happening.