### PR TITLE
Mb/update log 4 dep

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-athena" % awsJavaSdkVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.7",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
   "com.gu" %% "anghammarad-client" % "1.0.4",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")


### PR DESCRIPTION
## What does this change?

From DevX:

`Avulnerability was found in log4j (org.apache.logging.log4j), the popular Java logging library, affecting versions 2.0 to 2.14.1. There is a fix in 2.15.0.`

aws-lambda-java-log4j2 has a dependency on log4j-core so I've upgraded this library.

## How to test

`sbt dependencyTree | grep log4j                   
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info]   +-com.amazonaws:aws-lambda-java-log4j2:1.3.0
[info]   | +-org.apache.logging.log4j:log4j-api:2.15.0
[info]   | +-org.apache.logging.log4j:log4j-core:2.15.0
[info]   +-org.apache.logging.log4j:log4j-slf4j-impl:2.8.2
[info]   | +-org.apache.logging.log4j:log4j-core:2.15.0
[info]   | +-org.apache.logging.log4j:log4j-core:2.8.2 (evicted by: 2.15.0)
➜  data-lake-alerts git:(mb/update-log-4-dep) sbt test
`

sbt test - returned no failures.

## How can we measure success?

sbt dependency above shows patched 2.15.0 library is used. 

## Have we considered potential risks?

None

