### PR TITLE
Updated to aws-lambda-java-log4j2 1.5.1 as mitigation to CVE-2021-44228

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-athena" % awsJavaSdkVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.7",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
   "com.gu" %% "anghammarad-client" % "1.0.4",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
## What does this change?

 Versions 2.0 to 2.15.0 are vulnerable - a fix has recently been released as version 2.16.0. 2.15.0 is no longer sufficient to patch the vulnerability, upgrading to >=2.16.0 is an absolute requirement.
'
"org.apache.logging.log4j" % "log4j-core" % "2.17.0"
'

## How to test

' sbt dependencyTree | grep log4j       
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
[info] Resolving org.apache.logging.log4j#log4j-slf4j-impl;2.8.2 ...
[info]   +-com.amazonaws:aws-lambda-java-log4j2:1.5.1
[info]   | +-org.apache.logging.log4j:log4j-api:2.17.1
[info]   | +-org.apache.logging.log4j:log4j-core:2.17.1
[info]   +-org.apache.logging.log4j:log4j-slf4j-impl:2.8.2
[info]   | +-org.apache.logging.log4j:log4j-core:2.17.1
[info]   | +-org.apache.logging.log4j:log4j-core:2.8.2 (evicted by: 2.17.1)'

## How can we measure success?

sbt dependency above shows patched 2.15.0 library is used.

## Have we considered potential risks?

None

